### PR TITLE
Remove projects section and data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import Link from "next/link"
 
-import { contactLinks, navItems, projectCards, skillCategories, statusReadouts, upgradeIdeas } from "@/lib/portfolio-data"
+import { contactLinks, navItems, skillCategories, statusReadouts, upgradeIdeas } from "@/lib/portfolio-data"
 import { MatrixBackground } from "@/components/matrix-background"
 
 const asciiBanner = `
@@ -17,8 +17,6 @@ const asciiBanner = `
 `
 
 const terminalGreeting = "> INITIALIZING SYSTEM... WELCOME TO THE MATRIX"
-
-const projectStatuses = ["ACTIVE", "DEPLOYED", "BETA", "SCOPING"] as const
 
 function hashProgress(label: string, index: number) {
   let hash = 0
@@ -108,7 +106,7 @@ export default function MatrixPortfolio() {
               </p>
               <p>&gt; ROLE: IT Support Specialist → Cloud Operations</p>
               <p>&gt; LOCATION: Remote / Open to Relocation</p>
-              <p className="text-[#63ff64]">&gt; "There is no spoon. Only root cause analysis."</p>
+              <p className="text-[#63ff64]">&gt; &quot;There is no spoon. Only root cause analysis.&quot;</p>
             </div>
             <div className="mt-6 grid gap-4 md:grid-cols-3">
               {statusReadouts.map((readout) => (
@@ -175,49 +173,6 @@ export default function MatrixPortfolio() {
                   </div>
                 )
               })}
-            </div>
-          </section>
-        ) : null}
-
-        {activeSection === "projects" ? (
-          <section className="rounded-lg border-2 border-[#00ff41] bg-[#00160a]/95 p-8 shadow-lg shadow-[#00ff41]/30">
-            <h2 className="mb-6 flex items-center gap-2 text-2xl font-bold text-[#c5ffd2]">
-              <span className="animate-pulse">&gt;&gt;</span> PROJECTS.db
-            </h2>
-            <div className="space-y-4">
-              {projectCards.map((project, index) => (
-                <article
-                  key={project.title}
-                  className="rounded border border-[#004d1f] bg-black/40 p-6 transition-all duration-300 hover:border-[#00ff41] hover:shadow-lg hover:shadow-[#00ff41]/30"
-                >
-                  <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
-                    <h3 className="text-xl font-bold text-[#c5ffd2]">&gt; {project.title}</h3>
-                    <span className="rounded border border-[#00ff41]/60 px-3 py-1 text-xs tracking-[0.3em] text-[#7dff8c]">
-                      {projectStatuses[index % projectStatuses.length]}
-                    </span>
-                  </div>
-                  <p className="text-sm uppercase tracking-[0.2em] text-[#2cff4b]">{project.subtitle}</p>
-                  <p className="mt-3 text-[#c5ffd2]">{project.description}</p>
-                  <div className="mt-4 flex flex-wrap gap-2 text-xs text-[#63ff64]">
-                    {project.tags.map((tag) => (
-                      <span key={tag} className="rounded border border-[#004d1f] px-2 py-1">
-                        {tag.toUpperCase()}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="mt-4 flex flex-wrap gap-4 text-sm text-[#7dff8c]">
-                    <button type="button" className="transition-colors hover:text-[#c5ffd2]">
-                      [VIEW_CODE]
-                    </button>
-                    <button type="button" className="transition-colors hover:text-[#c5ffd2]">
-                      [DEMO]
-                    </button>
-                    <button type="button" className="transition-colors hover:text-[#c5ffd2]">
-                      [DOCS]
-                    </button>
-                  </div>
-                </article>
-              ))}
             </div>
           </section>
         ) : null}

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -39,7 +39,6 @@ export type UpgradeIdea = {
 export const navItems: NavItem[] = [
   { id: "about", label: "About", command: "./about" },
   { id: "skills", label: "Skills", command: "./skills" },
-  { id: "projects", label: "Projects", command: "./projects" },
   { id: "intel", label: "Intel", command: "./intel" },
   { id: "contact", label: "Contact", command: "./contact" },
 ]
@@ -113,36 +112,7 @@ export const skillCategories: SkillCategory[] = [
   },
 ]
 
-export const projectCards: ProjectCard[] = [
-  {
-    title: "Active Directory Control Lab",
-    subtitle: "Simulated corporate network with policy enforcement",
-    description:
-      "Engineered a Windows Server domain with staged OU policies, scripted provisioning, and break/fix drills to sharpen response time.",
-    tags: ["Windows Server", "Active Directory", "Group Policy", "Troubleshooting"],
-  },
-  {
-    title: "IT Service Desk Command Center",
-    subtitle: "osTicket deployment for realistic incident flow",
-    description:
-      "Deployed osTicket with SLA routing, form automation, and reporting views to practice structured ticket handling and communication.",
-    tags: ["osTicket", "Help Desk", "SLA", "Automation"],
-  },
-  {
-    title: "Secure AWS Storage Pipeline",
-    subtitle: "Guard-railed data access with IAM least privilege",
-    description:
-      "Built an S3-backed storage workflow including encryption, lifecycle policies, and IAM roles to demonstrate cloud security fundamentals.",
-    tags: ["AWS", "S3", "IAM", "Security"],
-  },
-  {
-    title: "Help Desk Field Manual",
-    subtitle: "Scenario-driven troubleshooting knowledge base",
-    description:
-      "Documented reproducible playbooks for recurring end-user issues with command references, verification steps, and rollback plans.",
-    tags: ["Documentation", "Process", "Troubleshooting", "Knowledge Base"],
-  },
-]
+export const projectCards: ProjectCard[] = []
 
 export const contactLinks: ContactLink[] = [
   {

--- a/tests/portfolio-data.test.ts
+++ b/tests/portfolio-data.test.ts
@@ -19,7 +19,7 @@ describe("portfolio data", () => {
   })
 
   it("orders nav items to match interactive sections", () => {
-    const expectedOrder = ["about", "skills", "projects", "intel", "contact"]
+    const expectedOrder = ["about", "skills", "intel", "contact"]
     expect(navItems.map((item) => item.id)).toEqual(expectedOrder)
   })
 
@@ -28,10 +28,8 @@ describe("portfolio data", () => {
     expect(protocols).toEqual(["mailto", "https", "https", "tel"])
   })
 
-  it("prioritises project storytelling", () => {
-    const tagCounts = projectCards.map((card) => card.tags.length)
-    expect(tagCounts.every((count) => count >= 4)).toBe(true)
-    expect(projectCards.map((card) => card.description.length).every((len) => len > 100)).toBe(true)
+  it("omits project cards when none are available", () => {
+    expect(projectCards).toHaveLength(0)
   })
 
   it("status readouts reinforce positioning", () => {
@@ -55,5 +53,6 @@ describe("portfolio data", () => {
 
     const sectionsFromNav = navItems.map((item) => item.id)
     expect(new Set(sectionsFromNav).size).toBe(sectionsFromNav.length)
+    expect(sectionsFromNav.includes("projects")).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- remove the Projects navigation entry and associated card data
- drop the Projects section from the landing page UI and escape the home quote for lint compliance
- update portfolio data tests to assert the absence of project cards

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eaee0310a08323aa16a1610adea68b