### PR TITLE
Update hero hero summary copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,9 +114,9 @@ export default function MatrixPortfolio() {
             <p>
               &gt; STATUS: <span className="text-[#63ff64]">ONLINE</span>
             </p>
-            <p>&gt; ROLE: IT Support Specialist → Cloud Operations</p>
-            <p>&gt; LOCATION: Remote / Open to Relocation</p>
-            <p className="text-[#63ff64]">&gt; &quot;There is no spoon. Only root cause analysis.&quot;</p>
+            <p>&gt; ROLE: IT Support Specialist</p>
+            <p>&gt; LOCATION: Menifee, CA</p>
+            <p className="text-[#63ff64]">&gt; Actively seeking IT Support Jobs</p>
           </div>
           <div className="mt-6 grid gap-4 md:grid-cols-3">
             {statusReadouts.map((readout) => (

--- a/tests/ui-adjustments.test.tsx
+++ b/tests/ui-adjustments.test.tsx
@@ -38,6 +38,26 @@ describe("UI adjustments", () => {
     expect(markup).toContain("#00b33c")
   })
 
+  it("shows updated hero summary copy without inspirational quote", () => {
+    const markup = renderToStaticMarkup(<MatrixPortfolio />)
+
+    expect(markup).toContain("&gt; STATUS: <span class=\"text-[#63ff64]\">ONLINE</span>")
+    expect(markup).toContain("&gt; ROLE: IT Support Specialist</p>")
+    expect(markup).toContain("&gt; LOCATION: Menifee, CA</p>")
+    expect(markup).toContain("&gt; Actively seeking IT Support Jobs</p>")
+    expect(markup).not.toContain("There is no spoon. Only root cause analysis.")
+  })
+
+  it("keeps hero summary free of unicode arrows (property)", () => {
+    const markup = renderToStaticMarkup(<MatrixPortfolio />)
+    const heroLines = [...markup.matchAll(/&gt; ([^<]+)</g)].map(([, text]) => text)
+
+    expect(heroLines.length).toBeGreaterThan(0)
+    for (const line of heroLines) {
+      expect(line.includes("→")).toBe(false)
+    }
+  })
+
   it("renders navigation commands for every section including home", () => {
     const markup = renderToStaticMarkup(<MatrixPortfolio />)
     const linkTexts = [...markup.matchAll(/<a[^>]+href=\"#([^"]+)\"[^>]*>(.*?)<\/a>/g)].map(([, , content]) =>


### PR DESCRIPTION
## Summary
- update the home hero section to reflect the new role, location, and call-to-action text
- add regression tests that assert the new strings and ensure the hero lines remain free of unicode arrows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f41cc6688c8323a2b5f8fb7b263e04